### PR TITLE
feat: search for string inside string template elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It replace string you choosed during babel runtime
         "rules": [
           {
             "search": "searchedString",
+            "searchTemplateStrings": true,
             "replace": "replacement"
           },
           {
@@ -32,7 +33,7 @@ It replace string you choosed during babel runtime
 }
 ```
 
-For Babel < 7 use babel-plugin-search-and-replace@0.3.0
+For Babel < 7 use babel-plugin-search-and-replace@0.3.0 (does not support template strings)
 
 ```json
 {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,25 +1,51 @@
+function visitor(path, state) {
+  const opts = state.opts;
+
+  if (Object.keys(opts).length === 0) {
+    return;
+  }
+
+  state.opts.rules.map((opt) => {
+    const isRegex = !!(opt.search && typeof opt.search === "object");
+    const searchTemplateStrings = !!(opt.searchTemplateStrings);
+    const isStringLiteral = path.node.type === "StringLiteral";
+
+    if (isStringLiteral) {
+      if (isRegex && path.node.value.match(opt.search)) {
+        path.node.value = path.node.value.replace(opt.search, opt.replace);
+        return;
+      }
+
+      if (path.node.value === opt.search) {
+        path.node.value = opt.replace;
+      }
+
+      return;
+    }
+
+    if (!searchTemplateStrings) {
+      return;
+    }
+
+    if (isRegex && path.node.value.raw.match(opt.search)) {
+      path.node.value.raw = path.node.value.raw.replace(
+        opt.search,
+        opt.replace
+      );
+      return;
+    }
+
+    if (path.node.value.raw === opt.search) {
+      path.node.value.raw = opt.replace;
+    }
+  });
+}
+
 module.exports = () => {
   return {
     visitor: {
-      StringLiteral(path, state) {
-        const opts = state.opts;
-
-        if (Object.keys(opts).length === 0) return;
-
-        state.opts.rules.map(opt => {
-          if (
-            typeof opt.search === "object" &&
-            path.node.value.match(opt.search)
-          ) {
-            path.node.value = path.node.value.replace(opt.search, opt.replace);
-            return;
-          }
-
-          if (path.node.value === opt.search) {
-            path.node.value = opt.replace;
-          }
-        });
-      }
-    }
+      StringLiteral: visitor,
+      TemplateElement: visitor,
+    },
   };
 };

--- a/tests/__snapshots__/index.spec.js.snap
+++ b/tests/__snapshots__/index.spec.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should replace bye for adios 1`] = `
+"var foo = 1;
+if (foo) console.log(foo);
+const bye = \`adios\${foo}\`;
+
+const myFunc = function (param = \`adios\${foo}\`) {
+  return 1;
+};"
+`;
+
 exports[`should replace el by aze 1`] = `
 "var foo = 1;
 if (foo) console.log(foo);
@@ -26,6 +36,16 @@ if (foo) console.log(foo);
 const hello = \\"hello\\";
 
 const myFunc = function (param = \\"hello\\") {
+  return 1;
+};"
+`;
+
+exports[`should replace ye by aby 1`] = `
+"var foo = 1;
+if (foo) console.log(foo);
+const bye = \`baby\${foo}\`;
+
+const myFunc = function (param = \`baby\${foo}\`) {
   return 1;
 };"
 `;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -78,3 +78,54 @@ it("should replace el by aze", () => {
   });
   expect(code).toMatchSnapshot();
 });
+
+
+var exampleWithTemplates = `
+var foo = 1;
+if (foo) console.log(foo);
+const bye = \`bye\${foo}\`;
+
+const myFunc = function(param = \`bye\${foo}\`){
+    return 1;
+}
+`;
+
+it("should replace bye for adios", () => {
+  const { code } = babel.transform(exampleWithTemplates, {
+    plugins: [
+      [
+        searchAndReplaceplugin,
+        {
+          rules: [
+            {
+              search: 'bye',
+              searchTemplateStrings: true,
+              replace: "adios",
+            }
+          ]
+        }
+      ]
+    ]
+  });
+  expect(code).toMatchSnapshot();
+});
+
+it("should replace ye by aby", () => {
+  const { code } = babel.transform(exampleWithTemplates, {
+    plugins: [
+      [
+        searchAndReplaceplugin,
+        {
+          rules: [
+            {
+              search: /ye/,
+              searchTemplateStrings: true,
+              replace: "aby",
+            }
+          ]
+        }
+      ]
+    ]
+  });
+  expect(code).toMatchSnapshot();
+});


### PR DESCRIPTION
This PR adds functionality to allow searching inside TemplateElement nodes:

```js
// Example Code
function myFunction(foo) {
  const bye = \`bye\${foo}\`;
}
```

Using this config:

```js
// Example .babelrc config
{
  "plugins": [
    [
      "search-and-replace",
      {
        "rules": [
          {
            "search": "bye",
            "includeTemplateStrings": true, // <--- boolean flag to enable/disable, default is disabled
            "replace": "adios"
          },
        ]
      }
    ]
  ]
}
```

Will output
```js
// Example Code
function myFunction(foo) {
  const bye = \`adios\${foo}\`;
}
```
